### PR TITLE
[WIP] Add generics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,12 @@ import WebSocket from 'isomorphic-ws';
 import { FullReport, ContractStatus, ContractSchema } from './types';
 
 /** Class representing a PAB (Plutus Application Backend) API. */
-export class Pab {
+export class Pab<Status, State> {
   axios: AxiosInstance;
 
   private sockets: { [key: string]: WebSocket } = {};
 
-  private socketURL: string;
+  private socketURL = '';
 
   /**
    * @param {string} baseURL - The base URL of PAB.
@@ -32,7 +32,7 @@ export class Pab {
    * Get full information about the PAB instance.
    * @return {Promise<Object>} - Promise fulfilled by the full report object.
    */
-  getFullReport = (): Promise<FullReport> =>
+  getFullReport = (): Promise<FullReport<Status, State>> =>
     this.axios.get('api/fullreport').then((res) => res.data);
 
   /**
@@ -56,7 +56,7 @@ export class Pab {
    * @param {string} contractInstanceId - Contract instance id.
    * @return {Promise<Object>} - Promise fulfilled by the contract instance's status object.
    */
-  getContractStatus = (contractInstanceId: string): Promise<ContractStatus> =>
+  getContractStatus = (contractInstanceId: string): Promise<ContractStatus<Status, State>> =>
     this.axios.get(`api/contract/instance/${contractInstanceId}/status`).then((res) => res.data);
 
   /**
@@ -64,7 +64,7 @@ export class Pab {
    * @param {string} contractInstanceId - Contract instance id.
    * @return {Promise<Object>} - Promise fulfilled by the contract instance's schema object.
    */
-  getContractSchema = (contractInstanceId: string): Promise<ContractSchema> =>
+  getContractSchema = (contractInstanceId: string): Promise<ContractSchema<Status>> =>
     this.axios.get(`api/contract/instance/${contractInstanceId}/schema`).then((res) => res.data);
 
   /**
@@ -97,21 +97,21 @@ export class Pab {
    * @param {string} walletId - Wallet Id.
    * @return {Promise<Array>} - Promise fulfilled by the wallet's contracts statuses array.
    */
-  getContractsByWallet = (walletId: string): Promise<ContractStatus[]> =>
+  getContractsByWallet = (walletId: string): Promise<ContractStatus<Status, State>[]> =>
     this.axios.get(`api/contract/instances/wallet/${walletId}`).then((res) => res.data);
 
   /**
    * Get all contract instances statuses by all wallets.
    * @return {Promise<Array>} - Promise fulfilled by all wallets contracts statuses array.
    */
-  getContracts = (): Promise<ContractStatus[]> =>
+  getContracts = (): Promise<ContractStatus<Status, State>[]> =>
     this.axios.get('api/contract/instances').then((res) => res.data);
 
   /**
    * Get all contracts definitions.
    * @return {Promise<Array>}
    */
-  getContractsDefinitions = (): Promise<ContractSchema[]> =>
+  getContractsDefinitions = (): Promise<ContractSchema<Status>[]> =>
     this.axios.get('api/contract/definitions').then((res) => res.data);
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
-export type FullReport = {
+export type FullReport<Status, State> = {
   contractReport: {
-    crAvailableContracts: ContractSchema[];
-    crActiveContractStates: ContractStateInFullReport[];
+    crAvailableContracts: ContractSchema<Status>[];
+    crActiveContractStates: ContractStateInFullReport<State>[];
   };
   chainReport: {
     utxoIndex: {
@@ -12,9 +12,9 @@ export type FullReport = {
   };
 };
 
-export type ContractSchema = {
+export type ContractSchema<Status> = {
   csrSchemas: EndpointSchema[];
-  csrDefinition: { tag: string };
+  csrDefinition: Status;
 };
 
 export type EndpointSchema = {
@@ -25,12 +25,12 @@ export type EndpointSchema = {
   endpointDescription: { getEndpointDescription: string };
 };
 
-export type ContractStateInFullReport = [
+export type ContractStateInFullReport<State> = [
   {
     unContractInstanceId: string;
   },
   {
-    observableState: any;
+    observableState: State;
     logs: ContractLog[];
     hooks: ContractHookInFullReport[];
     err: {
@@ -41,8 +41,8 @@ export type ContractStateInFullReport = [
   }
 ];
 
-export type ContractState = {
-  observableState: any;
+export type ContractState<State> = {
+  observableState: State;
   logs: ContractLog[];
   hooks: ContractHook[];
   err: {
@@ -77,14 +77,11 @@ export type ContractHook = {
   };
 };
 
-export type ContractStatus = {
-  cicCurrentState: ContractState;
+export type ContractStatus<Status, State> = {
+  cicCurrentState: ContractState<State>;
   cicContract: {
     unContractInstanceId: string;
   };
   cicWallet: { getWalletId: string };
-  cicDefinition: {
-    contents?: any; 
-    tag: string; 
-  };
+  cicDefinition: Status
 };


### PR DESCRIPTION
Adds generics for contract types. PAB's responses contain two main types that are of interest to the developer. The first type(Status) represents different types of contract instances. I.e. PAB may contain several types of contracts - for example, an owner contract and a user contract. The second type(State) represents all possible states of the contracts. Potentially it should be filtered using the contract type(in the aforementioned example, if we are querying user contract instance, we should receive user contract state). 